### PR TITLE
Allow Bsdec to load referenced assemblies in schemas

### DIFF
--- a/Bsdec/Functions/Decoder.cs
+++ b/Bsdec/Functions/Decoder.cs
@@ -1,6 +1,7 @@
 ﻿//-----------------------------------------------------------------------
 //
 // Copyright 2023 Jeremy Harding Hook
+// Copyright 2023 Dawid8
 //
 // This file is part of Bsdec.
 //
@@ -112,7 +113,7 @@ namespace Bsdec.Functions
 
             try
             {
-                return Assembly.LoadFile(Path.GetFullPath(filepath));
+                return Assembly.LoadFrom(Path.GetFullPath(filepath));
             }
             catch
             {


### PR DESCRIPTION
This pull request does one simple change - changes Assembly.LoadFile to Assembly.LoadFrom in Decoder.cs, which allows Bsdec to load referenced assemblies in schemas, which was previously not possible. This would lead to an exception being thrown during decoding if the schema was created based on a program that used external libraries. What should be kept in mind, is that  the referenced dll files should be right next to the schema file for this to work.